### PR TITLE
Missing requires

### DIFF
--- a/lib/truncato/truncated_sax_document.rb
+++ b/lib/truncato/truncated_sax_document.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'htmlentities'
 
 class TruncatedSaxDocument < Nokogiri::XML::SAX::Document
   attr_reader :truncated_string, :max_length, :max_length_reached, :tail, :count_tags, :filtered_attributes


### PR DESCRIPTION
Needed these requires to get it to work on my system.
FYI, my install is:
ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-darwin11.4.2]
Rails 3.2.12
nokogiri (1.5.6)
htmlentities (4.3.1)
