### PR TITLE
Update nokogiri dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,18 +3,18 @@ PATH
   specs:
     truncato (0.7.8)
       htmlentities (~> 4.3.1)
-      nokogiri (~> 1.6.1)
+      nokogiri (~> 1.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    html_truncator (0.3.1)
+    html_truncator (0.4.1)
       nokogiri (~> 1.5)
-    htmlentities (4.3.1)
-    mini_portile (0.5.2)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    htmlentities (4.3.4)
+    mini_portile2 (2.1.0)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
     peppercorn (0.0.3)
       nokogiri (~> 1.5)
     rake (10.1.1)
@@ -37,3 +37,6 @@ DEPENDENCIES
   rake (~> 10.1.1)
   rspec (~> 2.14.1)
   truncato!
+
+BUNDLED WITH
+   1.13.6

--- a/truncato.gemspec
+++ b/truncato.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.0.2"
   s.summary = "A tool for truncating HTML strings efficiently"
 
-  s.add_dependency "nokogiri", "~> 1.6.1"
+  s.add_dependency "nokogiri", "~> 1.7.0"
   s.add_dependency "htmlentities", "~> 4.3.1"
 
   s.add_development_dependency "rspec", '~> 2.14.1'


### PR DESCRIPTION
Hi!

I'm using tuncato on https://github.com/AjuntamentdeBarcelona/decidim and I'm trying to upgrade my project to use Ruby 2.4, but I'm getting some warnings due to not being able to upgrade nokogiri to its latest version (1.7.0.1 as of today). Truncato seems to be blocking nokogiri from upgrading since it requires nokogiri ~>1.6.1.

This PR updates nokogiri and html_truncator gems to their latest version so that we can use nokogiri 1.7 without problems.

Test suite was green on my machine.