### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     truncato (0.7.9)
       htmlentities (~> 4.3.1)
-      nokogiri (~> 1.7.0)
+      nokogiri (~> 1.8.0, >= 1.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,9 +12,9 @@ GEM
     html_truncator (0.4.1)
       nokogiri (~> 1.5)
     htmlentities (4.3.4)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.0.1)
-      mini_portile2 (~> 2.1.0)
+    mini_portile2 (2.2.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     peppercorn (0.0.3)
       nokogiri (~> 1.5)
     rake (10.1.1)
@@ -39,4 +39,4 @@ DEPENDENCIES
   truncato!
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/truncato.gemspec
+++ b/truncato.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.0.2"
   s.summary = "A tool for truncating HTML strings efficiently"
 
-  s.add_dependency "nokogiri", "~> 1.7.0"
+  s.add_dependency "nokogiri", ">= 1.7.0", "~> 1.8.0"
   s.add_dependency "htmlentities", "~> 4.3.1"
 
   s.add_development_dependency "rspec", '~> 2.14.1'


### PR DESCRIPTION
This updates nokogiri's dependency so it allows anything from `1.7.0` to `1.8.x` to be used.