### PR TITLE
fix: Missing string encoding and unicode composition

### DIFF
--- a/lib/truncato/truncato.rb
+++ b/lib/truncato/truncato.rb
@@ -31,7 +31,9 @@ module Truncato
 
   def self.do_truncate_html source, options
     truncated_sax_document = TruncatedSaxDocument.new(options)
-    parser = Nokogiri::HTML::SAX::Parser.new(truncated_sax_document)
+
+    # Only nokogiri >= 1.17 accept Encoding object, older needs a String as encoding
+    parser = Nokogiri::HTML::SAX::Parser.new(truncated_sax_document, source.encoding.to_s)
     parser.parse(source) { |context| context.replace_entities = false }
     truncated_string = truncated_sax_document.truncated_string
     truncated_string.empty? ? nil : truncated_string

--- a/lib/truncato/truncato.rb
+++ b/lib/truncato/truncato.rb
@@ -30,6 +30,18 @@ module Truncato
   end
 
   def self.do_truncate_html source, options
+    begin
+      source = source.unicode_normalize
+    rescue Encoding::CompatibilityError
+      # Only Unicode encodings can be normalized.
+      #
+      # Ruby docs:
+      # > In this context, 'Unicode Encoding' means any of UTF-8,
+      # > UTF-16BE/LE, and UTF-32BE/LE, as well as GB18030, UCS_2BE, and
+      # > UCS_4BE. Anything else than UTF-8 is implemented by converting
+      # > to UTF-8, which makes it slower than UTF-8.
+    end
+
     truncated_sax_document = TruncatedSaxDocument.new(options)
 
     # Only nokogiri >= 1.17 accept Encoding object, older needs a String as encoding

--- a/spec/truncato/truncato_spec.rb
+++ b/spec/truncato/truncato_spec.rb
@@ -14,6 +14,10 @@ describe "Truncato" do
                        with: { max_length: 8 },
                        source: 'Großer Übungs- und Beispieltext',
                        expected: 'Großer Ü...'
+    it_should_truncate 'with decomposed codes',
+                       with: { max_length: 8 },
+                       source: 'Großer Übungs- und Beispieltext'.unicode_normalize(:nfd),
+                       expected: 'Großer Ü...'
     it_should_truncate 'with multi-byte characters',
                        with: { max_length: 3, count_tags: false },
                        source: '<b>轉街過巷 就如滑過浪潮</b> 聽天說地 仍然剩我心跳',

--- a/spec/truncato/truncato_spec.rb
+++ b/spec/truncato/truncato_spec.rb
@@ -9,6 +9,24 @@ describe "Truncato" do
     it_should_truncate "no html text with longer length", with: {max_length: 5}, source: "some", expected: "some"
   end
 
+  describe 'unicode string' do
+    it_should_truncate 'text with non-ASCII characters',
+                       with: { max_length: 8 },
+                       source: 'Großer Übungs- und Beispieltext',
+                       expected: 'Großer Ü...'
+    it_should_truncate 'with multi-byte characters',
+                       with: { max_length: 3, count_tags: false },
+                       source: '<b>轉街過巷 就如滑過浪潮</b> 聽天說地 仍然剩我心跳',
+                       expected: '<b>轉街過...</b>'
+  end
+
+  describe 'non-unicode string' do
+    it_should_truncate 'text with non-unicode encodings',
+                       with: { max_length: 8 },
+                       source: 'Großer Übungs- und Beispieltext'.encode!(Encoding::ISO_8859_1),
+                       expected: 'Großer Ü...'
+  end
+
   describe "html tags structure" do
     it_should_truncate "html text with a tag (counting tags)", with: {max_length: 4}, source: "<p>some text</p>", expected: "<p>s...</p>"
 


### PR DESCRIPTION
Fixes #24.

One commit adds passing the source string encoding to Nokogiri. This will fix breaking any non-ASCII characters when truncating. The second commit adds additional Unicode normalization to avoid cutting off characters modifiers.