### PR TITLE
Tweak unicode normalization support

### DIFF
--- a/lib/truncato/truncato.rb
+++ b/lib/truncato/truncato.rb
@@ -33,8 +33,7 @@ module Truncato
   def self.do_truncate_html source, options
     truncated_sax_document = TruncatedSaxDocument.new(options)
 
-    # Only nokogiri >= 1.17 accept Encoding object, older needs a String as encoding
-    parser = Nokogiri::HTML::SAX::Parser.new(truncated_sax_document, source.encoding.to_s)
+    parser = Nokogiri::HTML::SAX::Parser.new(truncated_sax_document, source.encoding)
     parser.parse(source) { |context| context.replace_entities = false }
     truncated_string = truncated_sax_document.truncated_string
     truncated_string.empty? ? nil : truncated_string

--- a/lib/truncato/truncato.rb
+++ b/lib/truncato/truncato.rb
@@ -26,22 +26,11 @@ module Truncato
   private
 
   def self.truncate_html source, options
+    source = source.encoding == Encoding::UTF_8 ? source.unicode_normalize : source
     self.do_truncate_html(source, options) ? self.do_truncate_html(with_artificial_root(source), options) : nil
   end
 
   def self.do_truncate_html source, options
-    begin
-      source = source.unicode_normalize
-    rescue Encoding::CompatibilityError
-      # Only Unicode encodings can be normalized.
-      #
-      # Ruby docs:
-      # > In this context, 'Unicode Encoding' means any of UTF-8,
-      # > UTF-16BE/LE, and UTF-32BE/LE, as well as GB18030, UCS_2BE, and
-      # > UCS_4BE. Anything else than UTF-8 is implemented by converting
-      # > to UTF-8, which makes it slower than UTF-8.
-    end
-
     truncated_sax_document = TruncatedSaxDocument.new(options)
 
     # Only nokogiri >= 1.17 accept Encoding object, older needs a String as encoding

--- a/spec/truncato/truncato_spec.rb
+++ b/spec/truncato/truncato_spec.rb
@@ -9,26 +9,26 @@ describe "Truncato" do
     it_should_truncate "no html text with longer length", with: {max_length: 5}, source: "some", expected: "some"
   end
 
-  describe 'unicode string' do
-    it_should_truncate 'text with non-ASCII characters',
+  describe "unicode string" do
+    it_should_truncate "text with non-ASCII characters",
                        with: { max_length: 8 },
-                       source: 'Großer Übungs- und Beispieltext',
-                       expected: 'Großer Ü...'
-    it_should_truncate 'with decomposed codes',
+                       source: "Großer Übungs- und Beispieltext",
+                       expected: "Großer Ü..."
+    it_should_truncate "with decomposed codes",
                        with: { max_length: 8 },
-                       source: 'Großer Übungs- und Beispieltext'.unicode_normalize(:nfd),
-                       expected: 'Großer Ü...'
-    it_should_truncate 'with multi-byte characters',
+                       source: "Großer Übungs- und Beispieltext".unicode_normalize(:nfd),
+                       expected: "Großer Ü..."
+    it_should_truncate "with multi-byte characters",
                        with: { max_length: 3, count_tags: false },
-                       source: '<b>轉街過巷 就如滑過浪潮</b> 聽天說地 仍然剩我心跳',
-                       expected: '<b>轉街過...</b>'
+                       source: "<b>轉街過巷 就如滑過浪潮</b> 聽天說地 仍然剩我心跳",
+                       expected: "<b>轉街過...</b>"
   end
 
-  describe 'non-unicode string' do
-    it_should_truncate 'text with non-unicode encodings',
+  describe "non-unicode string" do
+    it_should_truncate "text with non-unicode encodings",
                        with: { max_length: 8 },
-                       source: 'Großer Übungs- und Beispieltext'.encode!(Encoding::ISO_8859_1),
-                       expected: 'Großer Ü...'
+                       source: "Großer Übungs- und Beispieltext".encode!(Encoding::ISO_8859_1),
+                       expected: "Großer Ü..."
   end
 
   describe "html tags structure" do


### PR DESCRIPTION
Follow up on https://github.com/jorgemanrubia/truncato/pull/25.

Since `truncate_html` calls `do_truncate_html` twice we can move the source normalisation outside `do_truncate_html`.

Only UTF-8 strings are compatible with `unicode_normalize`, we can check the encoding without relying on `rescue` for control flow.

The gem file locks nokogiri to above >= 1.17 so we shouldn’t have a problem with older versions.