### PR TITLE
Restore support for less common normalizable encodings and older nokogiri versions

### DIFF
--- a/lib/truncato/truncato.rb
+++ b/lib/truncato/truncato.rb
@@ -33,7 +33,9 @@ module Truncato
   def self.do_truncate_html source, options
     truncated_sax_document = TruncatedSaxDocument.new(options)
 
-    parser = Nokogiri::HTML::SAX::Parser.new(truncated_sax_document, source.encoding)
+    # Only nokogiri >= 1.17 accept Encoding object, older needs a String as encoding
+    parser = Nokogiri::HTML::SAX::Parser.new(truncated_sax_document, source.encoding.to_s)
+
     parser.parse(source) { |context| context.replace_entities = false }
     truncated_string = truncated_sax_document.truncated_string
     truncated_string.empty? ? nil : truncated_string

--- a/lib/truncato/truncato.rb
+++ b/lib/truncato/truncato.rb
@@ -26,8 +26,15 @@ module Truncato
   private
 
   def self.truncate_html source, options
-    source = source.encoding == Encoding::UTF_8 ? source.unicode_normalize : source
+    source = unicode_normalize(source)
     self.do_truncate_html(source, options) ? self.do_truncate_html(with_artificial_root(source), options) : nil
+  end
+
+  def self.unicode_normalize(string)
+    string.unicode_normalize
+  rescue Encoding::CompatibilityError
+    # By relying on rescue we don't have to maintain a list of compatible encodings.
+    string
   end
 
   def self.do_truncate_html source, options


### PR DESCRIPTION
Follow up on https://github.com/jorgemanrubia/truncato/pull/27.